### PR TITLE
reusable_go_lint_test: Support private repo authentication

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -57,9 +57,13 @@ jobs:
         id: set-build-secrets
         run: |
           SECRETS=""
-          [[ ! -z "${{ inputs.go-private-repos }}" ]] && SECRETS+="GO_PRIVATE_TOKEN=${{ secrets.GO_PRIVATE_TOKEN }}\n"
+          if [ -n "${{ inputs.go-private-repos }}" ]; then
+            SECRETS+='"GO_PRIVATE_TOKEN=${{ secrets.GO_PRIVATE_TOKEN }}"\n'
+          fi
           echo "::add-mask::$SECRETS"
-          echo $SECRETS >> "$GITHUB_OUTPUT"
+          echo "SECRETS<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$SECRETS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Build Docker image

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -51,7 +51,9 @@ jobs:
           else
             echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_ENV
           fi
-    
+   
+      # This block is used to not hard-coded the secrets in Build Docker image
+      # Secrets are only added when necessary 
       - name: Generate and mask build secrets
         id: set-build-secrets
         run: |

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -21,11 +21,10 @@ on:
         type: string
         description: "Custom repository name"
         default: ""
-      go-private-repos:
-        required: false
-        type: string
-        description: "Comma-separated list of private Go repositories"
-        default: ""
+      go-private-repos-authentication:
+        description: 'Enable authentication for private repositories'
+        type: boolean
+        default: false
 
 jobs:
   docker_build:
@@ -57,7 +56,7 @@ jobs:
         id: set-build-secrets
         run: |
           SECRETS=""
-          if [ -n "${{ inputs.go-private-repos }}" ]; then
+          if [ -n "${{ inputs.go-private-repos-authentication }}" ]; then
             SECRETS+='"GO_PRIVATE_TOKEN=${{ secrets.GO_PRIVATE_TOKEN }}"\n'
           fi
           echo "::add-mask::$SECRETS"

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -21,6 +21,11 @@ on:
         type: string
         description: "Custom repository name"
         default: ""
+      go-private-repos:
+        required: false
+        type: string
+        description: "Comma-separated list of private Go repositories"
+        default: ""
 
 jobs:
   docker_build:
@@ -47,6 +52,15 @@ jobs:
           else
             echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_ENV
           fi
+    
+      - name: Generate and mask build secrets
+        id: set-build-secrets
+        run: |
+          SECRETS=""
+          [[ ! -z "${{ inputs.go-private-repos }}" ]] && SECRETS+="GO_PRIVATE_TOKEN=${{ secrets.GO_PRIVATE_TOKEN }}\n"
+          echo "::add-mask::$SECRETS"
+          echo $SECRETS >> "$GITHUB_OUTPUT"
+        shell: bash
 
       - name: Build Docker image
         uses: docker/build-push-action@v6
@@ -55,6 +69,7 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ env.IMAGE_NAME }}.tar
           context: ${{ inputs.dockerContext }}
           file: ${{ inputs.dockerfile }}
+          secrets: ${{ steps.set-build-secrets.outputs.SECRETS }}
  
       - name: Upload Docker image to workspace
         if: inputs.publish == true

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -45,10 +45,10 @@ on:
         description: 'Run build'
         type: boolean
         default: false
-      go-private-repos:
-        description: 'Comma-separated list of private Go repositories'
-        type: string
-        default: ''
+      go-private-repos-authentication:
+        description: 'Enable authentication for private repositories'
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
-        if: ${{ inputs.go-private-repos != '' }}
+        if: ${{ inputs.go-private-repos-authentication }}
         run: |
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
@@ -102,7 +102,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
-        if: ${{ inputs.go-private-repos != '' }}
+        if: ${{ inputs.go-private-repos-authentication }}
         run: |
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
@@ -130,7 +130,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
-        if: ${{ inputs.go-private-repos != '' }}
+        if: ${{ inputs.go-private-repos-authentication }}
         run: |
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
@@ -162,7 +162,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
-        if: ${{ inputs.go-private-repos != '' }}
+        if: ${{ inputs.go-private-repos-authentication }}
         run: |
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
+      - name: Configure Git to use PAT for Private Modules
+        run: |
+          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - name: Print Go environment
         run: go env
 

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -45,6 +45,11 @@ on:
         description: 'Run build'
         type: boolean
         default: false
+      go-private-token:
+        description: 'Personal Access Token (PAT) for accessing private Go modules'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   build:

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Configure Git to use PAT for Private Modules
         run: |
-          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://oauth2:${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Print Go environment
         run: go env

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -45,6 +45,10 @@ on:
         description: 'Run build'
         type: boolean
         default: false
+      private-repos:
+        description: 'List all the private repos'
+        type: string
+        default: ''
     secrets:
       go-private-token:
         description: 'Personal Access Token (PAT) for accessing private Go modules'
@@ -62,6 +66,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
+
+      - name: Authenticate Go Private Modules
+        run: go env -w GOPRIVATE=github.com/${{ inputs.private-repos }}
 
       - name: Configure Git to use PAT for Private Modules
         run: |
@@ -122,6 +129,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
+
+      - name: Authenticate Go Private Modules
+        run: echo "${{ secrets.GO_PRIVATE_TOKEN }}" | go env -w GOPRIVATE=github.com/${{ inputs.private-repos }}
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -45,14 +45,14 @@ on:
         description: 'Run build'
         type: boolean
         default: false
-      private-repos:
-        description: 'List all the private repos'
+      go-private-repos:
+        description: 'Comma-separated list of private Go repositories'
         type: string
         default: ''
-    secrets:
-      go-private-token:
-        description: 'Personal Access Token (PAT) for accessing private Go modules'
-        required: false
+    # secrets:
+    #   go-private-token:
+    #     description: 'Personal Access Token (PAT) for accessing private Go modules'
+    #     required: false
 
 jobs:
   build:
@@ -67,12 +67,10 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
-      - name: Authenticate Go Private Modules
-        run: go env -w GOPRIVATE=github.com/${{ inputs.private-repos }}
-
-      - name: Configure Git to use PAT for Private Modules
+      - name: Configure Private Module Access
         run: |
-          git config --global url."https://oauth2:${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
+          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
+          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Print Go environment
         run: go env
@@ -107,6 +105,11 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
+      - name: Configure Private Module Access
+        run: |
+          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
+          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
+
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
         run: ${{ inputs.install-dependencies-command }}
@@ -130,8 +133,10 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
-      - name: Authenticate Go Private Modules
-        run: echo "${{ secrets.go-private-token }}" | go env -w GOPRIVATE=github.com/${{ inputs.private-repos }}
+      - name: Configure Private Module Access
+        run: |
+          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
+          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
@@ -159,6 +164,11 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go-version }}
+
+      - name: Configure Private Module Access
+        run: |
+          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
+          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -49,10 +49,6 @@ on:
         description: 'Comma-separated list of private Go repositories'
         type: string
         default: ''
-    # secrets:
-    #   go-private-token:
-    #     description: 'Personal Access Token (PAT) for accessing private Go modules'
-    #     required: false
 
 jobs:
   build:
@@ -68,9 +64,10 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
+        if: ${{ inputs.go-private-repos != '' }}
         run: |
           go env -w GOPRIVATE=${{ inputs.go-private-repos }}
-          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Print Go environment
         run: go env
@@ -106,9 +103,10 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
+        if: ${{ inputs.go-private-repos != '' }}
         run: |
           go env -w GOPRIVATE=${{ inputs.go-private-repos }}
-          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
@@ -134,9 +132,10 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
+        if: ${{ inputs.go-private-repos != '' }}
         run: |
           go env -w GOPRIVATE=${{ inputs.go-private-repos }}
-          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
@@ -166,9 +165,10 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Configure Private Module Access
+        if: ${{ inputs.go-private-repos != '' }}
         run: |
           go env -w GOPRIVATE=${{ inputs.go-private-repos }}
-          git config --global url."https://${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Configure Git to use PAT for Private Modules
         run: |
-          git config --global url."https://oauth2:${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://oauth2:${{ secrets.go-private-token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Print Go environment
         run: go env
@@ -131,7 +131,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Authenticate Go Private Modules
-        run: echo "${{ secrets.GO_PRIVATE_TOKEN }}" | go env -w GOPRIVATE=github.com/${{ inputs.private-repos }}
+        run: echo "${{ secrets.go-private-token }}" | go env -w GOPRIVATE=github.com/${{ inputs.private-repos }}
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -45,11 +45,10 @@ on:
         description: 'Run build'
         type: boolean
         default: false
+    secrets:
       go-private-token:
         description: 'Personal Access Token (PAT) for accessing private Go modules'
-        type: string
         required: false
-        default: ''
 
 jobs:
   build:

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos != '' }}
         run: |
-          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Print Go environment
@@ -105,7 +104,6 @@ jobs:
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos != '' }}
         run: |
-          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
@@ -134,7 +132,6 @@ jobs:
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos != '' }}
         run: |
-          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
@@ -167,7 +164,6 @@ jobs:
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos != '' }}
         run: |
-          go env -w GOPRIVATE=${{ inputs.go-private-repos }}
           git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4.0
+
+- reusable_go_lint_test: Add go-private-repos input, allowing access to private repositories
+
 ## 0.3.2
 
 - reusable_go_lint_test: Allow build job to be optional


### PR DESCRIPTION
This PR adds `go-private-repos-authentication` input to`go_lint_test` and `docker_pipeline` workflow to allow Golang  repos to use private modules. 
If the input is enabled, it will change the git config to use PAT when downloading packages.
One important thing to note here: while it's recommended to set `GOPRIVATE` to control which modules the go command considers to be private and should therefore not use the proxy or checksum database ([ref](https://play-with-go.dev/working-with-private-modules_go119_en/)), I decided not to add the variable to support it so that the workflow's caller is cleaner. One example of that variable can be
```
      go-private-repos:
          description: 'Comma-separated list of private Go repositories'
          type: string
          default: 'github.com/babylonlabs-io/babylon-privat'
```
which can be used as below in the `go_lint_test`
```
      - name: Configure Private Module Access
        if: ${{ inputs.go-private-repos != '' }}
        run: |
          go env -w GOPRIVATE=${{ inputs.go-private-repos }} # inputs.go-private-repos is used here
          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
```

To make the above consideration work, the `GOPROXY='https://proxy.golang.org,direct/` env must be set, which is true as it's the [default value](https://go.dev/doc/go1.13) (e.g You can check the `Print Go environment step` of [this workflow run](https://github.com/babylonlabs-io/finality-provider/actions/runs/10571584321/job/29288777767)). 

Also https://docs.docker.com/build/ci/github-actions/secrets was referred to mount secrets to docker which is useful when reviewing `docker_pipeline`.
Example of workflow caller PR https://github.com/babylonlabs-io/finality-provider/pull/43
