### PR TITLE
Huy/add docker sec

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -279,6 +279,7 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
+    - uses: actions/checkout@v3
     - name: Dockerfile Linting
       uses: hadolint/hadolint-action@v3.1.0
       with:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -283,3 +283,12 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
+    - name: Dockerfile Linting
+      uses: hadolint/hadolint-action@v3.1.0
+      with:
+        output-file: hadolint-result.sarif
+        format: sarif
+    - name: Upload linting results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: hadolint-result.sarif     

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -67,8 +67,6 @@ jobs:
     needs: 
       - prepare-metadata
       - dockerfile_lint
-    outputs:
-      dockerhub-sha: ${{ steps.build-dockerhub.outputs.digest}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,12 +252,12 @@ jobs:
     - name: Create Trivy config
       run: |
         cat <<EOF > /tmp/trivy.yaml
-          format: 'sarif'
-          # exit-code: '1'
-          ignore-unfixed: true  
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          db-repository: 'aquasec/trivy-db'
+        format: 'sarif'
+        # exit-code: '1'
+        ignore-unfixed: true  
+        vuln-type: 'os,library'
+        severity: 'CRITICAL,HIGH'
+        db-repository: 'aquasec/trivy-db'
         EOF 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -49,6 +49,8 @@ jobs:
   docker_build:
     runs-on: ${{ matrix.runner }}
     needs: prepare-metadata
+    outputs:
+      dockerhub-sha: ${{ steps.build-dockerhub.outputs.digest}}
     strategy:
       fail-fast: false
       matrix:
@@ -196,7 +198,7 @@ jobs:
       
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ needs.docker_build.outputs.dockerhub-sha }}
 
   merge_ecr:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -269,6 +269,7 @@ jobs:
     if: inputs.publish
     needs:
     - merge_dockerhub
+    - prepare-metadata
     steps:
     - name: Create Trivy config
       run: |

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: '${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}'
+        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: '1'

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -48,9 +48,6 @@ jobs:
 
   dockerfile_lint:
     runs-on: ubuntu-24.04
-    needs:
-      - docker_build
-      - prepare-metadata
     steps:
     - uses: actions/checkout@v3
     - name: Dockerfile Linting
@@ -67,7 +64,9 @@ jobs:
 
   docker_build:
     runs-on: ${{ matrix.runner }}
-    needs: prepare-metadata
+    needs: 
+      - prepare-metadata
+      - dockerfile_lint
     outputs:
       dockerhub-sha: ${{ steps.build-dockerhub.outputs.digest}}
     strategy:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -258,7 +258,7 @@ jobs:
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
         db-repository: 'aquasec/trivy-db'
-        EOF 
+        EOF
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
 
-  security_check:
+  vulnerability_scan:
     runs-on: ubuntu-latest
     # if: inputs.publish
     needs:
@@ -280,6 +280,15 @@ jobs:
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
+
+
+  dockerfile_lint:
+    runs-on: ubuntu-latest
+      # if: inputs.publish
+    needs:
+      - docker_build
+      - prepare-metadata
+    steps:
     - uses: actions/checkout@v3
     - name: Dockerfile Linting
       uses: hadolint/hadolint-action@v3.1.0

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -1,5 +1,9 @@
 name: Docker Build & Publish
-
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
 on:
   workflow_call:
     inputs:
@@ -248,11 +252,6 @@ jobs:
     needs:
     - docker_build
     - prepare-metadata
-    permissions:
-      # required for all workflows
-      security-events: write
-      # required to fetch internal or private CodeQL packs
-      packages: read
     steps:
     - name: Create Trivy config
       run: |

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -262,9 +262,10 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        # image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
-        image-ref: 'babylonlabs/btc-staker'
+        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}"
+        # image-ref: 'babylonlabs/btc-staker'
         output: 'trivy-results.sarif'
+        trivy-config: /tmp/trivy.yaml
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -48,7 +48,6 @@ jobs:
 
   dockerfile_lint:
     runs-on: ubuntu-24.04
-      # if: inputs.publish
     needs:
       - docker_build
       - prepare-metadata
@@ -266,7 +265,7 @@ jobs:
 
   vulnerability_scan:
     runs-on: ubuntu-24.04
-    # if: inputs.publish
+    if: inputs.publish
     needs:
     - docker_build
     - prepare-metadata

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -253,7 +253,7 @@ jobs:
       run: |
         cat <<EOF > /tmp/trivy.yaml
         format: sarif
-        # exit-code: '1'
+        exit-code: '1'
         output: trivy-results.sarif
         vulnerability:
           ignore-unfixed: true  
@@ -277,6 +277,7 @@ jobs:
         TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
+      if: always()
       with:
         sarif_file: 'trivy-results.sarif'
     - uses: actions/checkout@v3
@@ -285,7 +286,9 @@ jobs:
       with:
         output-file: hadolint-result.sarif
         format: sarif
+        failure-threshold: error
     - name: Upload linting results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
+      if: always()
       with:
         sarif_file: hadolint-result.sarif     

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -269,8 +269,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}"
-        # image-ref: 'babylonlabs/btc-staker'
+        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.build-dockerhub.outputs.digest }}"
         trivy-config: /tmp/trivy.yaml
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -259,6 +259,7 @@ jobs:
         ignore-unfixed: true
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
+        db-repository: 'aquasec/trivy-db'
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -254,6 +254,7 @@ jobs:
         cat <<EOF > /tmp/trivy.yaml
         format: sarif
         # exit-code: '1'
+        output: trivy-results.sarif
         vulnerability:
           ignore-unfixed: true  
           type: 
@@ -270,7 +271,6 @@ jobs:
       with:
         image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}"
         # image-ref: 'babylonlabs/btc-staker'
-        output: 'trivy-results.sarif'
         trivy-config: /tmp/trivy.yaml
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -249,18 +249,22 @@ jobs:
     - docker_build
     - prepare-metadata
     steps:
+    - name: Create Trivy config
+      run: |
+        cat <<EOF > /tmp/trivy.yaml
+          format: 'sarif'
+          exit-code: '1'
+          ignore-unfixed: true  
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          db-repository: 'aquasec/trivy-db'
+        EOF 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
         # image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
         image-ref: 'babylonlabs/btc-staker'
-        format: 'sarif'
         output: 'trivy-results.sarif'
-        exit-code: '1'
-        ignore-unfixed: true  
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'
-        db-repository: 'aquasec/trivy-db'
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -248,6 +248,10 @@ jobs:
     needs:
     - docker_build
     - prepare-metadata
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     steps:
     - name: Create Trivy config
       run: |

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -248,10 +248,6 @@ jobs:
     needs:
     - docker_build
     - prepare-metadata
-    permissions:
-      security-events: write
-      actions: read
-      contents: read
     steps:
     - name: Create Trivy config
       run: |

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         output-file: hadolint-result.sarif
         format: sarif
-        failure-threshold: error
+        no-fail: true
     - name: Upload linting results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       if: always()
@@ -275,7 +275,7 @@ jobs:
       run: |
         cat <<EOF > /tmp/trivy.yaml
         format: sarif
-        exit-code: '1'
+        exit-code: '0'
         output: trivy-results.sarif
         vulnerability:
           ignore-unfixed: true  

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,12 +252,18 @@ jobs:
     - name: Create Trivy config
       run: |
         cat <<EOF > /tmp/trivy.yaml
-        format: 'sarif'
+        format: sarif
         # exit-code: '1'
-        ignore-unfixed: true  
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'
-        db-repository: 'aquasec/trivy-db'
+        vulnerability:
+          ignore-unfixed: true  
+          type: 
+            - os
+            - library
+        severity: 
+          - CRITICAL
+          - HIGH
+        db:
+          repository: index.docker.io/aquasec/trivy-db:2
         EOF
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -248,6 +248,11 @@ jobs:
     needs:
     - docker_build
     - prepare-metadata
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
     steps:
     - name: Create Trivy config
       run: |

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
   dockerfile_lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
       # if: inputs.publish
     needs:
       - docker_build
@@ -265,7 +265,7 @@ jobs:
           docker buildx imagetools inspect ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
 
   vulnerability_scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # if: inputs.publish
     needs:
     - docker_build

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -271,7 +271,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ needs.docker_build.outputs.dockerhub-sha }}"
+        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}@${{ needs.docker_build.outputs.dockerhub-sha }}"
         trivy-config: /tmp/trivy.yaml
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -268,8 +268,6 @@ jobs:
     runs-on: ubuntu-24.04
     if: inputs.publish
     needs:
-    - docker_build
-    - prepare-metadata
     - merge_dockerhub
     steps:
     - name: Create Trivy config

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -241,3 +241,25 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
+
+  security_check:
+    runs-on: ubuntu-latest
+    # if: inputs.publish
+    needs:
+    - docker_build
+    - prepare-metadata
+    steps:
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: ${{ needs.prepare-metadata.outputs.image-name }}
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
+        severity: 'CRITICAL,HIGH'
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -253,7 +253,7 @@ jobs:
       run: |
         cat <<EOF > /tmp/trivy.yaml
           format: 'sarif'
-          exit-code: '1'
+          # exit-code: '1'
           ignore-unfixed: true  
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,17 +252,17 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
+        image-ref: ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: '1'
-        ignore-unfixed: true
+        ignore-unfixed: true  
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
         db-repository: 'aquasec/trivy-db'
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        TRIVY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -198,7 +198,7 @@ jobs:
       
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ needs.docker_build.outputs.dockerhub-sha }}
+          docker buildx imagetools inspect ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
 
   merge_ecr:
     runs-on: ubuntu-latest
@@ -271,7 +271,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.build-dockerhub.outputs.digest }}"
+        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ needs.docker_build.outputs.dockerhub-sha }}"
         trivy-config: /tmp/trivy.yaml
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -181,6 +181,8 @@ jobs:
     needs:
       - docker_build
       - prepare-metadata
+    outputs:
+      dockerhub_imgver: ${{ steps.meta.outputs.version }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -268,6 +270,7 @@ jobs:
     needs:
     - docker_build
     - prepare-metadata
+    - merge_dockerhub
     steps:
     - name: Create Trivy config
       run: |
@@ -289,7 +292,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}@${{ needs.docker_build.outputs.dockerhub-sha }}"
+        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ needs.merge_dockerhub.outputs.dockerhub_imgver }}"
         trivy-config: /tmp/trivy.yaml
       env:
         TRIVY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,7 +252,8 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
+        # image-ref: "${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
+        image-ref: 'babylonlabs/btc-staker'
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: '1'

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -1,9 +1,5 @@
 name: Docker Build & Publish
-permissions:
-  # required for all workflows
-  security-events: write
-  # required to fetch internal or private CodeQL packs
-  packages: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -46,6 +46,26 @@ jobs:
             echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_OUTPUT
           fi
 
+  dockerfile_lint:
+    runs-on: ubuntu-latest
+      # if: inputs.publish
+    needs:
+      - docker_build
+      - prepare-metadata
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dockerfile Linting
+      uses: hadolint/hadolint-action@v3.1.0
+      with:
+        output-file: hadolint-result.sarif
+        format: sarif
+        failure-threshold: error
+    - name: Upload linting results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: hadolint-result.sarif     
+
   docker_build:
     runs-on: ${{ matrix.runner }}
     needs: prepare-metadata
@@ -282,23 +302,3 @@ jobs:
       with:
         sarif_file: 'trivy-results.sarif'
 
-
-  dockerfile_lint:
-    runs-on: ubuntu-latest
-      # if: inputs.publish
-    needs:
-      - docker_build
-      - prepare-metadata
-    steps:
-    - uses: actions/checkout@v3
-    - name: Dockerfile Linting
-      uses: hadolint/hadolint-action@v3.1.0
-      with:
-        output-file: hadolint-result.sarif
-        format: sarif
-        failure-threshold: error
-    - name: Upload linting results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: hadolint-result.sarif     

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
+        image-ref: '${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}'
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: '1'

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.28.0
       with:
-        image-ref: ${{ needs.prepare-metadata.outputs.image-name }}
+        image-ref: ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
         format: 'sarif'
         output: 'trivy-results.sarif'
         exit-code: '1'
@@ -260,6 +260,9 @@ jobs:
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
         db-repository: 'aquasec/trivy-db'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:


### PR DESCRIPTION
Make following changes:
- Put hadolint in front of build step
- Dont fail the pipeline when error found, both on trivy and hadolint, upload the result anyway
- Pin the ubuntu version
- Remove the if line in hadolint, enable it on Trivy
Small adjustment: Trivy scan needs merge_dockerhub step for the image version