### PR TITLE
docker_pipeline: Support custom image tag and build-args

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -21,6 +21,11 @@ on:
         type: string
         description: "Custom repository name"
         default: ""
+      imageTag:
+        required: false
+        type: string
+        description: "Custom image tag"
+        default: ""
       go-private-repos-authentication:
         description: 'Enable authentication for private repositories'
         type: boolean
@@ -220,6 +225,7 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
             type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
+            type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
       
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -26,6 +26,11 @@ on:
         type: string
         description: "Custom image tag"
         default: ""
+      buildArgs:
+        type: string
+        description: 'Build arguments for Docker'
+        required: false
+        default: ""
       go-private-repos-authentication:
         description: 'Enable authentication for private repositories'
         type: boolean
@@ -155,6 +160,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: ${{ inputs.dockerContext }}
           file: ${{ inputs.dockerfile }}
+          build-args: ${{ inputs.buildArgs }}
           outputs: type=image,name=${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }},push-by-digest=true,push=${{ inputs.publish }}
 
       - name: Build and push to ECR
@@ -164,6 +170,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: ${{ inputs.dockerContext }}
           file: ${{ inputs.dockerfile }}
+          build-args: ${{ inputs.buildArgs }}
           outputs: type=image,name=${{ vars.AWS_ECR_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }},push-by-digest=true,push=${{ inputs.publish }}
       
       - name: Export digest Docker Hub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.12.0
+
+- reusable_docker_pipeline: Support custom image tag
+- reusable_docker_pipeline: Support build-args
+
 ## 0.11.2
 
 - reusable_docker_pipeline: Fix bug where a repo has both docker build workflow runs at the same time


### PR DESCRIPTION
- This PR adds:
  - `imageTag` input that allows the workflow caller to have custom image tag if needed. It can be used in the case of babylond repo where we need to build the image for testnet
  - `buildArgs` input that allows the workflow caller to have build arguments 