### PR TITLE
fix: Prevent docker pipeline from pushing to the same artifact

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -235,8 +235,8 @@ jobs:
         with:
           images: ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
           tags: |
-            type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
-            type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+            type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
           only-single-tag: true
 
@@ -280,9 +280,10 @@ jobs:
         with:
           images: ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
           tags: |
-            type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
-            type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+            type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
+          only-single-tag: true
 
       - name: Login to ECR
         uses: docker/login-action@v3

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -281,6 +281,7 @@ jobs:
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
             type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
+            type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
 
       - name: Login to ECR
         uses: docker/login-action@v3

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -191,7 +191,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}
+          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/dockerhub/*
           if-no-files-found: error
           retention-days: 1
@@ -200,7 +200,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}
+          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/ecr/*
           if-no-files-found: error
           retention-days: 1
@@ -218,7 +218,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}-*
+          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -262,7 +262,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}-*
+          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -191,7 +191,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
+          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/dockerhub/*
           if-no-files-found: error
           retention-days: 1
@@ -200,7 +200,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
+          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/ecr/*
           if-no-files-found: error
           retention-days: 1
@@ -218,7 +218,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
+          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -262,7 +262,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
+          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -239,7 +239,6 @@ jobs:
             type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
             type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
-          only-single-tag: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -284,7 +283,6 @@ jobs:
             type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
             type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
-          only-single-tag: true
 
       - name: Login to ECR
         uses: docker/login-action@v3

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -191,7 +191,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-${{ env.PLATFORM_PAIR }}
+          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/dockerhub/*
           if-no-files-found: error
           retention-days: 1
@@ -200,7 +200,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-${{ env.PLATFORM_PAIR }}
+          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/ecr/*
           if-no-files-found: error
           retention-days: 1
@@ -218,7 +218,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-*
+          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -262,7 +262,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.job }}-*
+          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -235,9 +235,10 @@ jobs:
         with:
           images: ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
           tags: |
-            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
-            type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
+            type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
+            type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
+          only-single-tag: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -279,8 +280,8 @@ jobs:
         with:
           images: ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
           tags: |
-            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
-            type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
+            type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
+            type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
 
       - name: Login to ECR

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -31,6 +31,8 @@ on:
         description: 'Build arguments for Docker'
         required: false
         default: ""
+      # Only needed when there are 2 jobs calling to workflow at the same time
+      # e.g babylond repo has 2 jobs to build mainnet/testnet images
       buildArtifactPrefix:
         type: string
         description: 'Build artifact prefix'

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")'  <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tags=$(jq -cr '.tags | first | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           digests=$(printf "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}@sha256:%s " $(ls /tmp/digests))
           docker buildx imagetools create $tags $digests
 
@@ -295,7 +295,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests/
         run: |
-          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")'  <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tags=$(jq -cr '.tags | first | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           digests=$(printf "${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}@sha256:%s " $(ls /tmp/digests))
           docker buildx imagetools create $tags $digests
 

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -191,7 +191,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
+          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/dockerhub/*
           if-no-files-found: error
           retention-days: 1
@@ -200,7 +200,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-${{ env.PLATFORM_PAIR }}
+          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/ecr/*
           if-no-files-found: error
           retention-days: 1
@@ -218,7 +218,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
+          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -262,7 +262,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ github.run_id }}-*
+          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -234,9 +234,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
+          # If inputs.imageTag is used, other tags will be ignored
           tags: |
-            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
-            type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
+            type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
+            type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
           only-single-tag: true
 
@@ -249,7 +250,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          tags=$(jq -cr '.tags | first | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")'  <<< "$DOCKER_METADATA_OUTPUT_JSON")
           digests=$(printf "${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}@sha256:%s " $(ls /tmp/digests))
           docker buildx imagetools create $tags $digests
 
@@ -280,8 +281,8 @@ jobs:
         with:
           images: ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
           tags: |
-            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
-            type=ref,enable=true,priority=200,prefix=,suffix=,event=tag
+            type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
+            type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
           only-single-tag: true
 
@@ -295,7 +296,7 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests/
         run: |
-          tags=$(jq -cr '.tags | first | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")'  <<< "$DOCKER_METADATA_OUTPUT_JSON")
           digests=$(printf "${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}@sha256:%s " $(ls /tmp/digests))
           docker buildx imagetools create $tags $digests
 

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -31,6 +31,11 @@ on:
         description: 'Build arguments for Docker'
         required: false
         default: ""
+      buildArtifactPrefix:
+        type: string
+        description: 'Build artifact prefix'
+        required: false
+        default: ""
       go-private-repos-authentication:
         description: 'Enable authentication for private repositories'
         type: boolean
@@ -191,7 +196,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-${{ env.PLATFORM_PAIR }}
+          name: ${{ inputs.buildArtifactPrefix }}digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/dockerhub/*
           if-no-files-found: error
           retention-days: 1
@@ -200,7 +205,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-${{ env.PLATFORM_PAIR }}
+          name: ${{ inputs.buildArtifactPrefix }}digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/ecr/*
           if-no-files-found: error
           retention-days: 1
@@ -218,7 +223,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-*
+          pattern: ${{ inputs.buildArtifactPrefix }}digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -262,7 +267,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ inputs.imageTag }}-*
+          pattern: ${{ inputs.buildArtifactPrefix }}digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -191,7 +191,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}
+          name: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}
           path: /tmp/digests/dockerhub/*
           if-no-files-found: error
           retention-days: 1
@@ -200,7 +200,7 @@ jobs:
         if: inputs.publish
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}
+          name: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}
           path: /tmp/digests/ecr/*
           if-no-files-found: error
           retention-days: 1
@@ -218,7 +218,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-*
+          pattern: digests-dockerhub-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -262,7 +262,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-*
+          pattern: digests-ecr-${{ needs.prepare-metadata.outputs.image-name }}-${{ env.PLATFORM_PAIR }}-${{ github.run_id }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -236,7 +236,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ vars.DOCKERHUB_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
-          # If inputs.imageTag is used, other tags will be ignored
+          # If inputs.imageTag is available, other tags will be ignored
+          # Priority only affects the order of tag generation, not which tag is chosen
           tags: |
             type=sha,enable=${{ !inputs.imageTag }},priority=100,prefix=,suffix=,format=long
             type=ref,enable=${{ !inputs.imageTag }},priority=200,prefix=,suffix=,event=tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.12.1
 
-- reusable_docker_pipeline: Add github_id to prevent uploading to the same artifact
+- reusable_docker_pipeline: Add buildArtifactPrefix to prevent uploading to the same artifact
+- reusable_docker_pipeline: Only use one tag when publishing
   
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.12.1
+
+- reusable_docker_pipeline: Add github_id to prevent uploading to the same artifact
+  
 ## 0.12.0
 
 - reusable_docker_pipeline: Support custom image tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.12.1
 
 - reusable_docker_pipeline: Add buildArtifactPrefix to prevent uploading to the same artifact
-- reusable_docker_pipeline: Only use one tag when publishing
+- reusable_docker_pipeline: Ignore other tag patterns when inputs.imageTag is available
   
 ## 0.12.0
 


### PR DESCRIPTION
This PR introduces a fix where a workflow has 2 jobs ([ref](https://github.com/babylonlabs-io/babylon/blob/main/.github/workflows/publish.yml#L22-L37)) that call the reusable_docker_pipeline, they will push to the same artifact, causing the duplication error.
Also as the 2 jobs are triggered from the same commit, they publish the container image to ec2 with the same tag. To prevent this from happening, if the job has custom image tag, it will ignore other tags