### PR TITLE
chore: bump golangci-lint

### DIFF
--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -120,7 +120,7 @@ jobs:
         run: ${{ inputs.install-dependencies-command }}
 
       - name: Run Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ inputs.go-lint-version }}
           args: --timeout=10m


### PR DESCRIPTION
Needed for go 1.24 and lint version v2.3.0