### PR TITLE
Re-add dockerfile_lint dependency to docker_build to block publishing…

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -127,12 +127,13 @@ jobs:
   dockerfile_lint:
     runs-on: ${{ inputs.runs_on_amd64 }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
-    if: inputs.docker_scan
     steps:
     - name: Checkout repository
+      if: inputs.docker_scan
       uses: actions/checkout@v4
 
     - name: Dockerfile Linting
+      if: inputs.docker_scan
       uses: hadolint/hadolint-action@v3.1.0
       with:
         output-file: hadolint-result.sarif
@@ -141,7 +142,7 @@ jobs:
         dockerfile: ${{ inputs.dockerfile }}
 
     - name: Add Hadolint results to Job Summary
-      if: always()
+      if: inputs.docker_scan && always()
       run: |
         echo "## 🐳 Hadolint Dockerfile Analysis" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -155,7 +156,7 @@ jobs:
 
     - name: Upload linting results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v4
-      if: always() && github.event.repository.visibility == 'public'
+      if: inputs.docker_scan && always() && github.event.repository.visibility == 'public'
       with:
         sarif_file: hadolint-result.sarif
         category: hadolint
@@ -165,6 +166,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     needs:
       - prepare-metadata
+      - dockerfile_lint
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.16.1
+- Re-add dockerfile_lint as a dependency of docker_build to block image publishing on lint failures
+
 ## 0.16.0
 - Restructure reusable Docker pipeline to scan images with Trivy (filesystem and image scans) before pushing to registries, with results published to GitHub Security tab via SARIF upload
 


### PR DESCRIPTION
… on lint failures

Context: https://babylonlabsworkspace.slack.com/archives/G07ES6D66AD/p1769791060593799?thread_ts=1769776264.514389&cid=G07ES6D66AD