### PR TITLE
fix: use env vars for workflow inputs in reusable workflows

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -118,20 +118,26 @@ jobs:
     steps:
       - name: Determine image name
         id: set_image_name
+        env:
+          REPO_NAME: ${{ inputs.repoName }}
         run: |
-          if [ -n "${{ inputs.repoName }}" ]; then
-            echo "IMAGE_NAME=${{ inputs.repoName }}" >> $GITHUB_OUTPUT
+          if [ -n "$REPO_NAME" ]; then
+            echo "IMAGE_NAME=$REPO_NAME" >> $GITHUB_OUTPUT
           else
-            echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)" >> $GITHUB_OUTPUT
+            echo "IMAGE_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d '/' -f 2)" >> $GITHUB_OUTPUT
           fi
 
       - name: Set build matrix
         id: set_matrix
+        env:
+          DISABLE_ARM64: ${{ inputs.disable_arm64 }}
+          RUNS_ON_AMD64: ${{ inputs.runs_on_amd64 }}
+          RUNS_ON_ARM64: ${{ inputs.runs_on_arm64 }}
         run: |
-          if [ "${{ inputs.disable_arm64 }}" == "true" ]; then
-            echo 'MATRIX={"include":[{"platform":"linux/amd64","runner":"${{ inputs.runs_on_amd64 }}"}]}' >> $GITHUB_OUTPUT
+          if [ "$DISABLE_ARM64" == "true" ]; then
+            echo "MATRIX={\"include\":[{\"platform\":\"linux/amd64\",\"runner\":\"${RUNS_ON_AMD64}\"}]}" >> $GITHUB_OUTPUT
           else
-            echo 'MATRIX={"include":[{"platform":"linux/amd64","runner":"${{ inputs.runs_on_amd64 }}"},{"platform":"linux/arm64","runner":"${{ inputs.runs_on_arm64 }}"}]}' >> $GITHUB_OUTPUT
+            echo "MATRIX={\"include\":[{\"platform\":\"linux/amd64\",\"runner\":\"${RUNS_ON_AMD64}\"},{\"platform\":\"linux/arm64\",\"runner\":\"${RUNS_ON_ARM64}\"}]}" >> $GITHUB_OUTPUT
           fi
 
   dockerfile_lint:
@@ -181,9 +187,10 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-metadata.outputs.matrix) }}
     steps:
       - name: Prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
@@ -234,13 +241,18 @@ jobs:
       # Secrets are only added when necessary
       - name: Generate and mask build secrets
         id: set-build-secrets
+        env:
+          GO_PRIVATE_AUTH: ${{ inputs.go-private-repos-authentication }}
+          PRIVATE_AUTH: ${{ inputs.private-repos-authentication }}
+          GO_PRIVATE_TOKEN: ${{ secrets.GO_PRIVATE_TOKEN }}
+          PRIVATE_REPO_TOKEN_VALUE: ${{ secrets.PRIVATE_REPO_TOKEN }}
         run: |
           SECRETS=""
-          if [ "${{ inputs.go-private-repos-authentication }}" == "true" ]; then
-            SECRETS+="GO_PRIVATE_TOKEN=${{ secrets.GO_PRIVATE_TOKEN }}\n"
+          if [ "$GO_PRIVATE_AUTH" == "true" ]; then
+            SECRETS+="GO_PRIVATE_TOKEN=${GO_PRIVATE_TOKEN}\n"
           fi
-          if [ "${{ inputs.private-repos-authentication }}" == "true" ]; then
-            SECRETS+="PRIVATE_REPO_TOKEN=${{ secrets.PRIVATE_REPO_TOKEN }}\n"
+          if [ "$PRIVATE_AUTH" == "true" ]; then
+            SECRETS+="PRIVATE_REPO_TOKEN=${PRIVATE_REPO_TOKEN_VALUE}\n"
           fi
           echo "::add-mask::$SECRETS"
           echo "SECRETS<<EOF" >> $GITHUB_OUTPUT
@@ -306,9 +318,10 @@ jobs:
           IMAGE_SCAN_OUTCOME: ${{ steps.image-scan.outcome }}
           FS_SECRET_OUTCOME: ${{ steps.fs-secret-scan.outcome }}
           IMAGE_SECRET_OUTCOME: ${{ steps.image-secret-scan.outcome }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           echo "## 🐳 Container Image Vulnerabilities" >> $GITHUB_STEP_SUMMARY
-          echo "Platform: \`${{ matrix.platform }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Platform: \`$PLATFORM\`" >> $GITHUB_STEP_SUMMARY
           case "$IMAGE_SCAN_OUTCOME" in
             failure)
               if [ -f trivy-image.txt ]; then
@@ -329,7 +342,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           # FS scan only runs on amd64 (source deps are platform-independent)
           echo "## 📦 Source Dependency Vulnerabilities" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ matrix.platform }}" != "linux/amd64" ]; then
+          if [ "$PLATFORM" != "linux/amd64" ]; then
             echo "ℹ️ Filesystem scan only runs on linux/amd64" >> $GITHUB_STEP_SUMMARY
           else
             case "$FS_SCAN_OUTCOME" in
@@ -352,7 +365,7 @@ jobs:
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 🔑 Image Secret Scan" >> $GITHUB_STEP_SUMMARY
-          echo "Platform: \`${{ matrix.platform }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Platform: \`$PLATFORM\`" >> $GITHUB_STEP_SUMMARY
           case "$IMAGE_SECRET_OUTCOME" in
             failure)
               if [ -f trivy-image-secrets.txt ]; then
@@ -372,7 +385,7 @@ jobs:
           esac
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 🔑 Filesystem Secret Scan" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ matrix.platform }}" != "linux/amd64" ]; then
+          if [ "$PLATFORM" != "linux/amd64" ]; then
             echo "ℹ️ Filesystem secret scan only runs on linux/amd64" >> $GITHUB_STEP_SUMMARY
           else
             case "$FS_SECRET_OUTCOME" in
@@ -462,22 +475,37 @@ jobs:
 
       - name: Login to Amazon ECR
         if: inputs.publish && inputs.push_to_ecr
+        env:
+          AWS_ECR_REGION: ${{ vars.AWS_ECR_REGION }}
+          AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
         run: |
-          aws ecr get-login-password --region ${{ vars.AWS_ECR_REGION }} | docker login --username AWS --password-stdin ${{ vars.AWS_ECR_REGISTRY_ID }}
+          aws ecr get-login-password --region "$AWS_ECR_REGION" | docker login --username AWS --password-stdin "$AWS_ECR_REGISTRY_ID"
 
       - name: Push to Docker Hub
         if: inputs.publish && inputs.push_to_dockerhub
+        env:
+          DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
+          IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
+          BUILD_PREFIX: ${{ inputs.buildArtifactPrefix }}
+          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
+          GIT_SHA: ${{ github.sha }}
         run: |
-          REPO="${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
-          docker tag "local-scan:${{ inputs.buildArtifactPrefix }}${{ github.sha }}" "$REPO:${{ inputs.imageTag || github.sha }}-${{ env.PLATFORM_PAIR }}"
-          docker push "$REPO:${{ inputs.imageTag || github.sha }}-${{ env.PLATFORM_PAIR }}"
+          REPO="${DOCKERHUB_REGISTRY}/${IMAGE_NAME}"
+          docker tag "local-scan:${BUILD_PREFIX}${GIT_SHA}" "$REPO:${IMAGE_TAG}-${PLATFORM_PAIR}"
+          docker push "$REPO:${IMAGE_TAG}-${PLATFORM_PAIR}"
 
       - name: Push to ECR
         if: inputs.publish && inputs.push_to_ecr
+        env:
+          AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
+          IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
+          BUILD_PREFIX: ${{ inputs.buildArtifactPrefix }}
+          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
+          GIT_SHA: ${{ github.sha }}
         run: |
-          REPO="${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}"
-          docker tag "local-scan:${{ inputs.buildArtifactPrefix }}${{ github.sha }}" "$REPO:${{ inputs.imageTag || github.sha }}-${{ env.PLATFORM_PAIR }}"
-          docker push "$REPO:${{ inputs.imageTag || github.sha }}-${{ env.PLATFORM_PAIR }}"
+          REPO="${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}"
+          docker tag "local-scan:${BUILD_PREFIX}${GIT_SHA}" "$REPO:${IMAGE_TAG}-${PLATFORM_PAIR}"
+          docker push "$REPO:${IMAGE_TAG}-${PLATFORM_PAIR}"
 
   merge_dockerhub:
     runs-on: ${{ inputs.runs_on_amd64 }}
@@ -511,19 +539,27 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create manifest list and push
+        env:
+          DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
+          IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
+          BUILD_MATRIX: ${{ needs.prepare-metadata.outputs.matrix }}
+          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
         run: |
           first_tag=$(jq -r '.tags[0] // empty' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -z "$first_tag" ]; then
             echo "No tag found in DOCKER_METADATA_OUTPUT_JSON"; exit 1
           fi
-          REPO="${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}"
-          # e.g. babylonlabs/babylond:abc123sha-linux-amd64 babylonlabs/babylond:abc123sha-linux-arm64
-          source_tags=$(echo '${{ needs.prepare-metadata.outputs.matrix }}' | jq -r '.include[].platform | gsub("/"; "-")' | xargs -I{} echo "$REPO:${{ inputs.imageTag || github.sha }}-{}" | tr '\n' ' ')
+          REPO="${DOCKERHUB_REGISTRY}/${IMAGE_NAME}"
+          source_tags=$(echo "$BUILD_MATRIX" | jq -r '.include[].platform | gsub("/"; "-")' | xargs -I{} echo "$REPO:${IMAGE_TAG}-{}" | tr '\n' ' ')
           docker buildx imagetools create -t "$first_tag" $source_tags
 
       - name: Inspect image
+        env:
+          DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
+          IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "${DOCKERHUB_REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}"
 
   merge_ecr:
     runs-on: ${{ inputs.runs_on_amd64 }}
@@ -558,20 +594,31 @@ jobs:
           aws-region: ${{ vars.AWS_ECR_REGION }}
 
       - name: Login to Amazon ECR
+        env:
+          AWS_ECR_REGION: ${{ vars.AWS_ECR_REGION }}
+          AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
         run: |
-          aws ecr get-login-password --region ${{ vars.AWS_ECR_REGION }} | docker login --username AWS --password-stdin ${{ vars.AWS_ECR_REGISTRY_ID }}
+          aws ecr get-login-password --region "$AWS_ECR_REGION" | docker login --username AWS --password-stdin "$AWS_ECR_REGISTRY_ID"
 
       - name: Create manifest list and push
+        env:
+          AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
+          IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
+          BUILD_MATRIX: ${{ needs.prepare-metadata.outputs.matrix }}
+          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
         run: |
           first_tag=$(jq -r '.tags[0] // empty' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -z "$first_tag" ]; then
             echo "No tag found in DOCKER_METADATA_OUTPUT_JSON"; exit 1
           fi
-          REPO="${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}"
-          # e.g. 123456789.dkr.ecr.us-east-1.amazonaws.com/babylond:abc123sha-linux-amd64 123456789.dkr.ecr.us-east-1.amazonaws.com/babylond:abc123sha-linux-arm64
-          source_tags=$(echo '${{ needs.prepare-metadata.outputs.matrix }}' | jq -r '.include[].platform | gsub("/"; "-")' | xargs -I{} echo "$REPO:${{ inputs.imageTag || github.sha }}-{}" | tr '\n' ' ')
+          REPO="${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}"
+          source_tags=$(echo "$BUILD_MATRIX" | jq -r '.include[].platform | gsub("/"; "-")' | xargs -I{} echo "$REPO:${IMAGE_TAG}-{}" | tr '\n' ' ')
           docker buildx imagetools create -t "$first_tag" $source_tags
 
       - name: Inspect image
+        env:
+          AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
+          IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}:${IMAGE_VERSION}"

--- a/.github/workflows/reusable_github_release.yml
+++ b/.github/workflows/reusable_github_release.yml
@@ -52,26 +52,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Generate base release notes
+        env:
+          DESCRIPTION: ${{ inputs.description }}
         run: |
           tee release_notes.md <<EOF
           # 🚀 Overview
 
-          ${{ inputs.description }}
+          $DESCRIPTION
           EOF
 
       - name: Append changelog section (if enabled)
         if: inputs.changelog_path
+        env:
+          CHANGELOG_PATH: ${{ inputs.changelog_path }}
         run: |
           tee -a release_notes.md <<EOF
 
           # 📄 Changelog
 
-          You can view the complete changelog [here](${{ inputs.changelog_path }})
+          You can view the complete changelog [here]($CHANGELOG_PATH)
           EOF
 
       - name: Append Build from Source section (if enabled)
         if: inputs.build_command
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          BUILD_COMMAND: ${{ inputs.build_command }}
         run: |
+          REPO_NAME=$(basename "$REPO")
           tee -a release_notes.md <<EOF
 
           # 🏗️ Binaries
@@ -79,40 +88,45 @@ jobs:
           If you prefer to build from source, use the following commands:
 
           \`\`\`sh
-          git clone https://github.com/${{ github.repository }}.git
-          cd $(basename ${{ github.repository }})
-          git checkout ${{ inputs.tag }}
-          ${{ inputs.build_command }}
+          git clone https://github.com/${REPO}.git
+          cd ${REPO_NAME}
+          git checkout ${TAG}
+          ${BUILD_COMMAND}
           \`\`\`
           EOF
 
       - name: Append Docker Image section (if enabled)
         if: inputs.docker_image_name || inputs.docker_image_table_template
+        env:
+          DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
+          DOCKER_IMAGE_TABLE: ${{ inputs.docker_image_table_template }}
         run: |
-          if [[ -z "${{ inputs.docker_image_table_template }}" ]]; then
+          if [[ -z "$DOCKER_IMAGE_TABLE" ]]; then
             tee -a release_notes.md <<EOF
 
           # 🐳 Docker Image
 
           | Image | Description |
           |---------------|----------------|
-          | \`${{ inputs.docker_image_name }}\` | Official release image |
+          | \`${DOCKER_IMAGE_NAME}\` | Official release image |
           EOF
           else
             tee -a release_notes.md <<EOF
           # 🐳 Docker Image
-          ${{ inputs.docker_image_table_template }}
+          ${DOCKER_IMAGE_TABLE}
           EOF
           fi
 
       - name: Append Dependencies (if enabled)
         if: inputs.dependencies_template
+        env:
+          DEPENDENCIES: ${{ inputs.dependencies_template }}
         run: |
           tee -a release_notes.md <<EOF
 
           # 📦 Dependencies
 
-          ${{ inputs.dependencies_template }}
+          $DEPENDENCIES
           EOF
 
       - name: Create GitHub release

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -86,8 +86,10 @@ jobs:
 
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos-authentication }}
+        env:
+          GO_PRIVATE_TOKEN: ${{ secrets.GO_PRIVATE_TOKEN }}
         run: |
-          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${GO_PRIVATE_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Print Go environment
         run: go env
@@ -105,7 +107,9 @@ jobs:
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
-        run: ${{ inputs.install-dependencies-command }}
+        env:
+          INSTALL_CMD: ${{ inputs.install-dependencies-command }}
+        run: eval "$INSTALL_CMD"
 
       - name: Build Application
         run: make build
@@ -125,12 +129,16 @@ jobs:
 
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos-authentication }}
+        env:
+          GO_PRIVATE_TOKEN: ${{ secrets.GO_PRIVATE_TOKEN }}
         run: |
-          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${GO_PRIVATE_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
-        run: ${{ inputs.install-dependencies-command }}
+        env:
+          INSTALL_CMD: ${{ inputs.install-dependencies-command }}
+        run: eval "$INSTALL_CMD"
 
       - name: Run Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8 https://github.com/golangci/golangci-lint-action/releases/tag/v8
@@ -159,10 +167,13 @@ jobs:
       # Download file if cache miss
       - name: Download test data (if cache miss)
         if: ${{ inputs.testdata-url != '' && steps.cache-testdata.outputs.cache-hit != 'true' }}
+        env:
+          TESTDATA_URL: ${{ inputs.testdata-url }}
+          TESTDATA_PATH: ${{ inputs.testdata-path }}
         run: |
-          echo "Cache miss — downloading test data from ${{ inputs.testdata-url }} to ${{ inputs.testdata-path }}..."
-          mkdir -p "$(dirname "${{ inputs.testdata-path }}")"
-          curl -L -o "${{ inputs.testdata-path }}" "${{ inputs.testdata-url }}"
+          echo "Cache miss — downloading test data from $TESTDATA_URL to $TESTDATA_PATH..."
+          mkdir -p "$(dirname "$TESTDATA_PATH")"
+          curl -L -o "$TESTDATA_PATH" "$TESTDATA_URL"
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
@@ -171,12 +182,16 @@ jobs:
 
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos-authentication }}
+        env:
+          GO_PRIVATE_TOKEN: ${{ secrets.GO_PRIVATE_TOKEN }}
         run: |
-          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${GO_PRIVATE_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
-        run: ${{ inputs.install-dependencies-command }}
+        env:
+          INSTALL_CMD: ${{ inputs.install-dependencies-command }}
+        run: eval "$INSTALL_CMD"
 
       - name: Run Unit Tests
         run: |
@@ -204,15 +219,21 @@ jobs:
 
       - name: Configure Private Module Access
         if: ${{ inputs.go-private-repos-authentication }}
+        env:
+          GO_PRIVATE_TOKEN: ${{ secrets.GO_PRIVATE_TOKEN }}
         run: |
-          git config --global url."https://${{ secrets.GO_PRIVATE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${GO_PRIVATE_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
-        run: ${{ inputs.install-dependencies-command }}
+        env:
+          INSTALL_CMD: ${{ inputs.install-dependencies-command }}
+        run: eval "$INSTALL_CMD"
 
       - name: Run Integration Tests
-        run: ${{ inputs.integration-tests-command }}
+        env:
+          TEST_CMD: ${{ inputs.integration-tests-command }}
+        run: eval "$TEST_CMD"
 
   check-mock-gen:
     permissions:
@@ -229,7 +250,9 @@ jobs:
 
       - name: Install Dependencies
         if: ${{ inputs.install-dependencies-command != '' }}
-        run: ${{ inputs.install-dependencies-command }}
+        env:
+          INSTALL_CMD: ${{ inputs.install-dependencies-command }}
+        run: eval "$INSTALL_CMD"
 
       - name: Run make mock-gen
         run: make mock-gen

--- a/.github/workflows/reusable_node_lint_test.yml
+++ b/.github/workflows/reusable_node_lint_test.yml
@@ -55,16 +55,20 @@ jobs:
 
     steps:
     - name: Validate Inputs
+      env:
+        INPUT_PUBLISH: ${{ inputs.publish }}
+        INPUT_CHANGESETS: ${{ inputs.run-changesets }}
+        INPUT_SEMANTIC: ${{ inputs.use-semantic-release }}
       run: |
-        if [ "${{ inputs.publish }}" = "true" ] && [ "${{ inputs.run-changesets }}" = "true" ]; then
+        if [ "$INPUT_PUBLISH" = "true" ] && [ "$INPUT_CHANGESETS" = "true" ]; then
           echo "Error: Both 'publish' and 'run-changesets' cannot be true at the same time."
           exit 1
         fi
-        if [ "${{ inputs.publish }}" = "true" ] && [ "${{ inputs.use-semantic-release }}" = "true" ]; then
+        if [ "$INPUT_PUBLISH" = "true" ] && [ "$INPUT_SEMANTIC" = "true" ]; then
           echo "Error: Cannot use both 'publish' and 'use-semantic-release' at the same time."
           exit 1
         fi
-        if [ "${{ inputs.run-changesets }}" = "true" ] && [ "${{ inputs.use-semantic-release }}" = "true" ]; then
+        if [ "$INPUT_CHANGESETS" = "true" ] && [ "$INPUT_SEMANTIC" = "true" ]; then
           echo "Error: Cannot use both 'run-changesets' and 'use-semantic-release' at the same time."
           exit 1
         fi
@@ -111,4 +115,6 @@ jobs:
 
     - name: Publish package
       if: ${{ inputs.publish }}
-      run: ${{ inputs.publish-command }}
+      env:
+        PUBLISH_CMD: ${{ inputs.publish-command }}
+      run: eval "$PUBLISH_CMD"

--- a/.github/workflows/reusable_sync_branch.yml
+++ b/.github/workflows/reusable_sync_branch.yml
@@ -35,44 +35,43 @@ jobs:
 
       - name: Check for commits in base branch but not in target branch
         id: check_commits
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
-          base_branch=${{ inputs.base_branch }}
-          target_branch=${{ inputs.target_branch }}
+          echo "Checking for commits in $BASE_BRANCH that are not in $TARGET_BRANCH..."
 
-          echo "Checking for commits in $base_branch that are not in $target_branch..."
-
-          new_commits=$(git log origin/$base_branch --not origin/$target_branch --oneline)
+          new_commits=$(git log "origin/$BASE_BRANCH" --not "origin/$TARGET_BRANCH" --oneline)
 
           if [ -z "$new_commits" ]; then
-            echo "No unique commits found in $base_branch that are not in $target_branch."
+            echo "No unique commits found in $BASE_BRANCH that are not in $TARGET_BRANCH."
             echo "no_diff=true" >> $GITHUB_ENV
           else
-            echo "Unique commits in $base_branch that are not in $target_branch:"
+            echo "Unique commits in $BASE_BRANCH that are not in $TARGET_BRANCH:"
             echo "$new_commits"
             echo "no_diff=false" >> $GITHUB_ENV
           fi
 
       - name: Check for existing PR and create if not exists
         if: env.no_diff == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          REVIEWERS: ${{ inputs.reviewers }}
+          REPO: ${{ github.repository }}
         run: |
-          base_branch="${{ inputs.base_branch }}"
-          target_branch="${{ inputs.target_branch }}"
-          reviewers="${{ inputs.reviewers }}"
-          repo="${{ github.repository }}"
-
-          pr_exists=$(gh pr list --base "$target_branch" --head "$base_branch" --repo "$repo" --json number --jq '.[0].number')
+          pr_exists=$(gh pr list --base "$TARGET_BRANCH" --head "$BASE_BRANCH" --repo "$REPO" --json number --jq '.[0].number')
 
           if [ -n "$pr_exists" ]; then
             echo "A pull request already exists: #$pr_exists"
           else
-            gh pr create --base "$target_branch" \
-            --head "$base_branch" \
-            --title "Sync from $base_branch to $target_branch" \
-            --body "This PR synchronizes changes from $base_branch to $target_branch." \
-            --repo "$repo" \
-            --reviewer "$reviewers"
+            gh pr create --base "$TARGET_BRANCH" \
+            --head "$BASE_BRANCH" \
+            --title "Sync from $BASE_BRANCH to $TARGET_BRANCH" \
+            --body "This PR synchronizes changes from $BASE_BRANCH to $TARGET_BRANCH." \
+            --repo "$REPO" \
+            --reviewer "$REVIEWERS"
 
             echo "Pull request created successfully."
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace direct ${{ inputs.xxx }} interpolation in `run:` blocks with intermediate environment variables across all 5 affected reusable workflows
- Follows the same pattern already established in `reusable_authenticate_commits.yml`
- Covers `reusable_sync_branch`, `reusable_github_release`, `reusable_go_lint_test`, `reusable_node_lint_test`, `reusable_docker_pipeline`

Expressions in `run:` blocks are expanded at YAML parse time (before shell execution). Passing them through `env:` blocks instead means values are only expanded at shell execution time, which is the [GitHub-recommended approach](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

**Note:** Some inputs (`install-dependencies-command`, `integration-tests-command`, `publish-command`) are designed to execute caller-provided commands via `eval`. The env var approach prevents issues during script generation, but a future improvement would be to replace these with composite actions or script file references to avoid passing raw shell commands as workflow inputs entirely.

No functional changes — all workflow behavior is preserved.