### PR TITLE
feat(check-pinned-actions): add # unversioned sentinel for SHA-only pins

### DIFF
--- a/.github/workflows/reusable_check_pinned_actions.yml
+++ b/.github/workflows/reusable_check_pinned_actions.yml
@@ -67,6 +67,7 @@ jobs:
           COUNT_LOOKUP_FAIL=0
           COUNT_NO_COMMENT=0
           COUNT_SKIPPED_REMOTE=0
+          COUNT_SENTINEL=0
 
           # ── scan ──────────────────────────────────────────────────────────
 
@@ -77,6 +78,8 @@ jobs:
               # Extract owner/repo/[subpath]@<ref> — handles both `uses:` and `- uses:`
               action=$(echo "$trimmed" | sed 's/.*uses: //' | awk '{print $1}')
               ref="${action##*@}"
+              # owner/repo — strip subpath (e.g. github/codeql-action/upload-sarif -> github/codeql-action)
+              repo=$(echo "$action" | cut -d'@' -f1 | cut -d'/' -f1,2)
 
               # ── Check 1: must be a full 40-char SHA ──────────────────────
               if ! echo "$ref" | grep -qE '^[0-9a-f]{40}$'; then
@@ -97,6 +100,20 @@ jobs:
                 continue
               fi
 
+              # ── Check 2.5: SHA-only sentinel ─────────────────────────────
+              # Comment value "unversioned" opts out of remote tag resolution
+              # for actions whose maintainers don't publish stable release
+              # tags (e.g. dtolnay/rust-toolchain ships via branch channels).
+              # The SHA is still locked to a 40-char hex string (Check 1) and
+              # the developer must consciously type the sentinel — preserving
+              # the "no random commits" guarantee while accepting that no
+              # remote validation is possible.
+              if [ "$version" = "unversioned" ]; then
+                echo "SHA-ONLY  ${repo}@${ref}"
+                COUNT_SENTINEL=$((COUNT_SENTINEL + 1))
+                continue
+              fi
+
               # ── Check 3: reject mutable branch refs ──────────────────────
               if [ "$version" = "master" ] || [ "$version" = "main" ]; then
                 echo "BRANCH REF  [$file]"
@@ -106,9 +123,6 @@ jobs:
                 COUNT_MISMATCH=$((COUNT_MISMATCH + 1))
                 continue
               fi
-
-              # owner/repo — strip subpath (e.g. github/codeql-action/upload-sarif -> github/codeql-action)
-              repo=$(echo "$action" | cut -d'@' -f1 | cut -d'/' -f1,2)
 
               # ── Check 4: skip-list check ──────────────────────────────────
               reason=$(skip_reason "$repo")
@@ -177,6 +191,7 @@ jobs:
           echo "  No version tag       : $COUNT_NO_COMMENT"
           echo "  Lookup failed        : $COUNT_LOOKUP_FAIL"
           echo "  Skipped (allowlisted): $COUNT_SKIPPED_REMOTE"
+          echo "  SHA-only (sentinel)  : $COUNT_SENTINEL"
           echo "─────────────────────────────────────────"
 
           if [ "$FAILED" -ne 0 ]; then

--- a/.github/workflows/reusable_check_pinned_actions.yml
+++ b/.github/workflows/reusable_check_pinned_actions.yml
@@ -108,6 +108,12 @@ jobs:
               # the developer must consciously type the sentinel — preserving
               # the "no random commits" guarantee while accepting that no
               # remote validation is possible.
+              #
+              # POLICY: using `# unversioned` requires DevOps review, same
+              # bar as adding an entry to SKIP_REMOTE_CHECK. The free-form
+              # text after the sentinel should justify why no release tag
+              # is available (e.g. "upstream-publishes-via-branch-channels").
+              # Reviewers can grep `# unversioned` to find every opt-out.
               if [ "$version" = "unversioned" ]; then
                 echo "SHA-ONLY  ${repo}@${ref}"
                 COUNT_SENTINEL=$((COUNT_SENTINEL + 1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 0.19.2
+- ci: `reusable_check_pinned_actions` accepts `# unversioned` sentinel comment to allow SHA-only pinning for actions whose maintainers don't publish release tags (e.g. `dtolnay/rust-toolchain`). The SHA must still be a 40-char hex string; remote tag resolution is skipped.
+
 ## 0.19.0
 - security: pin all GitHub Actions to full commit SHAs across all reusable workflows
 - ci: add `reusable_check_pinned_actions` workflow — verifies all `uses:` entries are pinned to commit SHAs and match the remote tag via the GitHub API; supports a skip list for orgs with IP allowlists (e.g. `aquasecurity`)


### PR DESCRIPTION
## Summary

Adds **Check 2.5** to `reusable_check_pinned_actions.yml`: when an action's pin comment value is the literal string `unversioned`, the SHA is accepted as-is with no remote tag resolution.

```yaml
# example use:
- uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # unversioned upstream-publishes-via-branch-channels
```

The 40-char SHA requirement (Check 1) and the comment-required gate (Check 2) still apply — reviewers can grep `# unversioned` to find every opt-out site.

## Why

Some action maintainers ship via branch channels (`stable`, `nightly`, `master`) instead of release tags. `dtolnay/rust-toolchain` is the immediate driver: a single force-pushed `v1` tag exists, all real code lives on `stable`/`master`. Without this sentinel:

- pinning to current `stable` HEAD passes today but breaks the audit on the next upstream push (~6 weeks)
- pinning to `v1` works but locks us 8 months behind master and requires extra inputs in some call sites
- `SKIP_REMOTE_CHECK` doesn't help — it bypasses Checks 5/6 but Check 2 still requires a real version tag

`# unversioned` is the explicit, grep-able opt-out for this case.

## Release

CHANGELOG entry under `## 0.19.2` (patch — purely additive, no existing call site changes behavior).