### PR TITLE
chore: upgrade GitHub Actions to latest pinned versions

### DIFF
--- a/.github/workflows/reusable_backport.yml
+++ b/.github/workflows/reusable_backport.yml
@@ -49,6 +49,6 @@ jobs:
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     steps:
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2 https://github.com/tibdex/backport/releases/tag/v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4 https://github.com/tibdex/backport/releases/tag/v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -205,7 +205,7 @@ jobs:
         id: fs-scan
         if: inputs.docker_scan && matrix.platform == 'linux/amd64'
         continue-on-error: true
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -223,7 +223,7 @@ jobs:
         id: fs-secret-scan
         if: inputs.docker_scan && matrix.platform == 'linux/amd64'
         continue-on-error: true
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -236,7 +236,7 @@ jobs:
           version: v0.69.2 # https://github.com/aquasecurity/trivy-action/issues/512
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3 https://github.com/docker/setup-buildx-action/releases/tag/v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0
       # This block is used to not hard-coded the secrets in Build Docker image
       # Secrets are only added when necessary
       - name: Generate and mask build secrets
@@ -263,7 +263,7 @@ jobs:
       # Build image locally for scanning (not pushed yet)
       - name: Build image for scanning
         id: build-local
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6 https://github.com/docker/build-push-action/releases/tag/v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2 https://github.com/docker/build-push-action/releases/tag/v6.19.2
         with:
           platforms: ${{ matrix.platform }}
           context: ${{ inputs.dockerContext }}
@@ -282,7 +282,7 @@ jobs:
         id: image-scan
         if: inputs.docker_scan
         continue-on-error: true
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0
         with:
           image-ref: 'local-scan:${{ inputs.buildArtifactPrefix }}${{ github.sha }}'
           format: 'table'
@@ -299,7 +299,7 @@ jobs:
         id: image-secret-scan
         if: inputs.docker_scan
         continue-on-error: true
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0
         with:
           image-ref: 'local-scan:${{ inputs.buildArtifactPrefix }}${{ github.sha }}'
           scanners: 'secret'
@@ -434,7 +434,7 @@ jobs:
       - name: Run Trivy filesystem scan (SARIF)
         id: sarif-scan
         if: inputs.docker_scan && matrix.platform == 'linux/amd64' && github.event.repository.visibility == 'public'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -460,14 +460,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: inputs.publish && inputs.push_to_dockerhub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3 https://github.com/docker/login-action/releases/tag/v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0 https://github.com/docker/login-action/releases/tag/v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Configure AWS credentials
         if: inputs.publish && inputs.push_to_ecr
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4 https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1 https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.3.1
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ECR_ACCOUNT }}:role/gha-ecr-push
           role-session-name: gh-docker-build-${{ github.run_id }}
@@ -518,10 +518,10 @@ jobs:
       dockerhub_imgver: ${{ steps.meta.outputs.version }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3 https://github.com/docker/setup-buildx-action/releases/tag/v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5 https://github.com/docker/metadata-action/releases/tag/v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0 https://github.com/docker/metadata-action/releases/tag/v5.10.0
         with:
           images: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}/${{ needs.prepare-metadata.outputs.image-name }}
           # If inputs.imageTag is available, other tags will be ignored
@@ -533,7 +533,7 @@ jobs:
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3 https://github.com/docker/login-action/releases/tag/v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0 https://github.com/docker/login-action/releases/tag/v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -572,10 +572,10 @@ jobs:
       ecr_imgver: ${{ steps.meta.outputs.version }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3 https://github.com/docker/setup-buildx-action/releases/tag/v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5 https://github.com/docker/metadata-action/releases/tag/v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0 https://github.com/docker/metadata-action/releases/tag/v5.10.0
         with:
           images: ${{ vars.AWS_ECR_REGISTRY_ID }}/${{ needs.prepare-metadata.outputs.image-name }}
           flavor: |
@@ -587,7 +587,7 @@ jobs:
             type=raw,enable=${{ !!inputs.imageTag }},priority=300,value=${{ inputs.imageTag }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4 https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1 https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.3.1
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ECR_ACCOUNT }}:role/gha-ecr-push
           role-session-name: gh-docker-build-${{ github.run_id }}

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Cache Go modules
         id: go-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 https://github.com/actions/cache/releases/tag/v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0
         with:
           path: |
             ~/.go/pkg/mod
@@ -123,7 +123,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -141,7 +141,7 @@ jobs:
         run: eval "$INSTALL_CMD"
 
       - name: Run Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8 https://github.com/golangci/golangci-lint-action/releases/tag/v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0 https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0
         with:
           version: ${{ inputs.go-lint-version }}
           args: --timeout=10m
@@ -159,7 +159,7 @@ jobs:
       - name: Restore test data cache
         if: ${{ inputs.testdata-url != '' }}
         id: cache-testdata
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 https://github.com/actions/cache/releases/tag/v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 https://github.com/actions/cache/releases/tag/v4.3.0
         with:
           path: ${{ inputs.testdata-path }}
           key: testdata-${{ inputs.testdata-url }}-${{ inputs.testdata-path }}
@@ -176,7 +176,7 @@ jobs:
           curl -L -o "$TESTDATA_PATH" "$TESTDATA_URL"
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -207,13 +207,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Login to Docker Hub
         if: ${{ inputs.integration-tests-docker-auth == 'true' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3 https://github.com/docker/login-action/releases/tag/v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0 https://github.com/docker/login-action/releases/tag/v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
 
@@ -244,7 +244,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
         with:
           go-version: ${{ inputs.go-version }}
 

--- a/.github/workflows/reusable_go_releaser.yml
+++ b/.github/workflows/reusable_go_releaser.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 https://github.com/actions/setup-go/releases/tag/v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6 https://github.com/goreleaser/goreleaser-action/releases/tag/v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action/releases/tag/v6.4.0
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/reusable_node_lint_test.yml
+++ b/.github/workflows/reusable_node_lint_test.yml
@@ -79,7 +79,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 https://github.com/actions/setup-node/releases/tag/v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: 'https://registry.npmjs.org'
@@ -101,7 +101,7 @@ jobs:
 
     - name: Create Release Pull Request
       if: ${{ inputs.run-changesets }}
-      uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1 https://github.com/changesets/action/releases/tag/v1
+      uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0 https://github.com/changesets/action/releases/tag/v1.7.0
       with:
         publish: ${{ inputs.publish-command }}
       env:


### PR DESCRIPTION
## Summary

- Upgrade all `uses:` references in `.github/workflows/` to the latest full `vX.Y.Z` versions
- Pin each action to its immutable 40-char commit SHA
- Version tag preserved in trailing comment (e.g. `# v6.0.2 https://...`) for readability

## Why

SHA pinning prevents supply-chain attacks: a version tag can be silently force-pushed to malicious code, but a commit SHA is immutable.

## Files changed

-     Files updated: reusable_backport.yml reusable_docker_pipeline.yml reusable_go_lint_test.yml reusable_go_releaser.yml reusable_node_lint_test.yml
-  .github/workflows/reusable_backport.yml        |  2 +-
-  .github/workflows/reusable_docker_pipeline.yml | 30 +++++++++++++-------------
-  .github/workflows/reusable_go_lint_test.yml    | 18 ++++++++--------
-  .github/workflows/reusable_go_releaser.yml     |  4 ++--
-  .github/workflows/reusable_node_lint_test.yml  |  4 ++--

## Pinned actions

- actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
- actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
- actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
- aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
- aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
- changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
- docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
- docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
- docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
- docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
- golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
- goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
- tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4