### PR TITLE
fix(docker-pipeline): avoid ECR immutable-tag collision on tag-after-branch builds

### DIFF
--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -115,6 +115,7 @@ jobs:
     outputs:
       image-name: ${{ steps.set_image_name.outputs.IMAGE_NAME }}
       matrix: ${{ steps.set_matrix.outputs.MATRIX }}
+      image-tag: ${{ steps.set_image_tag.outputs.IMAGE_TAG }}
     steps:
       - name: Determine image name
         id: set_image_name
@@ -139,6 +140,37 @@ jobs:
           else
             echo "MATRIX={\"include\":[{\"platform\":\"linux/amd64\",\"runner\":\"${RUNS_ON_AMD64}\"},{\"platform\":\"linux/arm64\",\"runner\":\"${RUNS_ON_ARM64}\"}]}" >> $GITHUB_OUTPUT
           fi
+
+      # Resolve a single Docker-safe IMAGE_TAG once and reuse it across the
+      # build and merge jobs. Resolution order:
+      #   1. inputs.imageTag (caller override)
+      #   2. ref name on tag events (e.g. v0.1.0)
+      #   3. github.sha
+      # Then sanitize to match docker/metadata-action: replace any char
+      # outside [A-Za-z0-9._-] with `-`, and strip leading `-`/`.` which
+      # Docker rejects. This prevents tags like `release/v1.0.0` or
+      # `v1.0.0+build.1` from producing invalid intermediate Docker tags.
+      - name: Determine image tag
+        id: set_image_tag
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.imageTag }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            RAW="$INPUT_IMAGE_TAG"
+          elif [ "$REF_TYPE" = "tag" ]; then
+            RAW="$REF_NAME"
+          else
+            RAW="$GIT_SHA"
+          fi
+          SAFE=$(printf '%s' "$RAW" | sed -E -e 's|[^A-Za-z0-9_.-]|-|g' -e 's|^[.-]+||')
+          if [ -z "$SAFE" ]; then
+            echo "::error::Resolved image tag is empty after sanitization (raw='$RAW')"
+            exit 1
+          fi
+          echo "IMAGE_TAG=$SAFE" >> "$GITHUB_OUTPUT"
 
   dockerfile_lint:
     runs-on: ${{ inputs.runs_on_amd64 }}
@@ -487,7 +519,7 @@ jobs:
           DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_PREFIX: ${{ inputs.buildArtifactPrefix }}
-          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
+          IMAGE_TAG: ${{ needs.prepare-metadata.outputs.image-tag }}
           GIT_SHA: ${{ github.sha }}
         run: |
           REPO="${DOCKERHUB_REGISTRY}/${IMAGE_NAME}"
@@ -500,10 +532,7 @@ jobs:
           AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_PREFIX: ${{ inputs.buildArtifactPrefix }}
-          # Use tag ref on tag events so per-platform intermediates don't collide
-          # with the SHA-named ones produced by a prior branch push at the same SHA
-          # (ECR tag immutability rejects re-pushing identical <sha>-<platform> tags).
-          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
+          IMAGE_TAG: ${{ needs.prepare-metadata.outputs.image-tag }}
           GIT_SHA: ${{ github.sha }}
         run: |
           REPO="${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}"
@@ -546,8 +575,7 @@ jobs:
           DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_MATRIX: ${{ needs.prepare-metadata.outputs.matrix }}
-          # Must match the IMAGE_TAG used in docker_build's push step
-          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
+          IMAGE_TAG: ${{ needs.prepare-metadata.outputs.image-tag }}
         run: |
           first_tag=$(jq -r '.tags[0] // empty' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -z "$first_tag" ]; then
@@ -609,8 +637,7 @@ jobs:
           AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_MATRIX: ${{ needs.prepare-metadata.outputs.matrix }}
-          # Must match the IMAGE_TAG used in docker_build's push step
-          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
+          IMAGE_TAG: ${{ needs.prepare-metadata.outputs.image-tag }}
         run: |
           first_tag=$(jq -r '.tags[0] // empty' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -z "$first_tag" ]; then

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -487,7 +487,7 @@ jobs:
           DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_PREFIX: ${{ inputs.buildArtifactPrefix }}
-          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
+          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
           GIT_SHA: ${{ github.sha }}
         run: |
           REPO="${DOCKERHUB_REGISTRY}/${IMAGE_NAME}"
@@ -500,7 +500,10 @@ jobs:
           AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_PREFIX: ${{ inputs.buildArtifactPrefix }}
-          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
+          # Use tag ref on tag events so per-platform intermediates don't collide
+          # with the SHA-named ones produced by a prior branch push at the same SHA
+          # (ECR tag immutability rejects re-pushing identical <sha>-<platform> tags).
+          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
           GIT_SHA: ${{ github.sha }}
         run: |
           REPO="${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}"
@@ -543,7 +546,8 @@ jobs:
           DOCKERHUB_REGISTRY: ${{ vars.DOCKERHUB_REGISTRY_ID || 'babylonlabs' }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_MATRIX: ${{ needs.prepare-metadata.outputs.matrix }}
-          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
+          # Must match the IMAGE_TAG used in docker_build's push step
+          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
         run: |
           first_tag=$(jq -r '.tags[0] // empty' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -z "$first_tag" ]; then
@@ -605,7 +609,8 @@ jobs:
           AWS_ECR_REGISTRY_ID: ${{ vars.AWS_ECR_REGISTRY_ID }}
           IMAGE_NAME: ${{ needs.prepare-metadata.outputs.image-name }}
           BUILD_MATRIX: ${{ needs.prepare-metadata.outputs.matrix }}
-          IMAGE_TAG: ${{ inputs.imageTag || github.sha }}
+          # Must match the IMAGE_TAG used in docker_build's push step
+          IMAGE_TAG: ${{ inputs.imageTag || (github.ref_type == 'tag' && github.ref_name) || github.sha }}
         run: |
           first_tag=$(jq -r '.tags[0] // empty' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -z "$first_tag" ]; then

--- a/.github/workflows/reusable_docker_pipeline.yml
+++ b/.github/workflows/reusable_docker_pipeline.yml
@@ -141,15 +141,6 @@ jobs:
             echo "MATRIX={\"include\":[{\"platform\":\"linux/amd64\",\"runner\":\"${RUNS_ON_AMD64}\"},{\"platform\":\"linux/arm64\",\"runner\":\"${RUNS_ON_ARM64}\"}]}" >> $GITHUB_OUTPUT
           fi
 
-      # Resolve a single Docker-safe IMAGE_TAG once and reuse it across the
-      # build and merge jobs. Resolution order:
-      #   1. inputs.imageTag (caller override)
-      #   2. ref name on tag events (e.g. v0.1.0)
-      #   3. github.sha
-      # Then sanitize to match docker/metadata-action: replace any char
-      # outside [A-Za-z0-9._-] with `-`, and strip leading `-`/`.` which
-      # Docker rejects. This prevents tags like `release/v1.0.0` or
-      # `v1.0.0+build.1` from producing invalid intermediate Docker tags.
       - name: Determine image tag
         id: set_image_tag
         env:
@@ -536,8 +527,13 @@ jobs:
           GIT_SHA: ${{ github.sha }}
         run: |
           REPO="${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}"
-          docker tag "local-scan:${BUILD_PREFIX}${GIT_SHA}" "$REPO:${IMAGE_TAG}-${PLATFORM_PAIR}"
-          docker push "$REPO:${IMAGE_TAG}-${PLATFORM_PAIR}"
+          TAG="${IMAGE_TAG}-${PLATFORM_PAIR}"
+          if aws ecr describe-images --repository-name "$IMAGE_NAME" --image-ids imageTag="$TAG" >/dev/null 2>&1; then
+            echo "$REPO:$TAG already present in ECR, skipping push"
+          else
+            docker tag "local-scan:${BUILD_PREFIX}${GIT_SHA}" "$REPO:$TAG"
+            docker push "$REPO:$TAG"
+          fi
 
   merge_dockerhub:
     runs-on: ${{ inputs.runs_on_amd64 }}
@@ -645,7 +641,11 @@ jobs:
           fi
           REPO="${AWS_ECR_REGISTRY_ID}/${IMAGE_NAME}"
           source_tags=$(echo "$BUILD_MATRIX" | jq -r '.include[].platform | gsub("/"; "-")' | xargs -I{} echo "$REPO:${IMAGE_TAG}-{}" | tr '\n' ' ')
-          docker buildx imagetools create -t "$first_tag" $source_tags
+          if aws ecr describe-images --repository-name "$IMAGE_NAME" --image-ids imageTag="${first_tag##*:}" >/dev/null 2>&1; then
+            echo "$first_tag already present in ECR, skipping manifest creation"
+          else
+            docker buildx imagetools create -t "$first_tag" $source_tags
+          fi
 
       - name: Inspect image
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.20.1
+- reusable_docker_pipeline: resolve `IMAGE_TAG` to the ref name on tag events so a tag push no longer collides with the `<sha>`-named intermediate tags left by an earlier branch build of the same commit
+- reusable_docker_pipeline: skip ECR pushes when the target tag already exists, making re-runs idempotent against ECR tag immutability
+
 ## 0.20.0
 - security: **breaking** — remove `reusable_node_lint_test.yml` (BPT-056; instance of BPT-049). The workflow ran unpinned `npm install` and `npx semantic-release` in a job with `id-token: write`, `contents: write`, and `pull-requests: write`. It is no longer consumed: all former callers are archived or migrated to `babylon-toolkit`'s own release pipeline, and the last non-archived caller (`btc-staking-ts`) is scheduled for archival. Migration: repos still pinning historical tags for Node CI should move to the `babylon-toolkit` pipeline; the removed workflow remains reachable via tags ≤ v0.19.x and must not be adopted by new repos.
 


### PR DESCRIPTION
## Summary

- `reusable_docker_pipeline.yml` fails on a tag push when the same commit was already built on a branch (e.g. `main`), because both runs try to push the identical per-platform intermediate `<sha>-linux-<arch>` and ECR's tag immutability blocks the second push.
- Fix: resolve `IMAGE_TAG` to `github.ref_name` on tag events, so intermediates become `v0.1.0-linux-<arch>` — never colliding with the SHA-named ones from the prior branch build. Branch pushes still default to `github.sha`.
- Applied in both `docker_build` push steps and both `merge_{dockerhub,ecr}` source-tag computations so manifest assembly still finds its inputs.

## Real-world failure that motivated this

`vault-provider-proxy` v0.1.0 tag publish failed at the ECR push step:

> tag invalid: The image tag `f5b06b8a969f752f5c5c2c6d2e216683fe3456c4-linux-arm64` already exists in the `vault-provider-proxy` repository and cannot be overwritten because the tag is immutable.

Run: https://github.com/babylonlabs-io/vault-provider-proxy/actions/runs/26803556947/job/79020072602

## Test plan

- [ ] Cut a pre-release of this `.github` repo (or temporarily pin a downstream caller at this branch's SHA).
- [ ] Push a commit to a caller repo's `main`; confirm `docker_build` pushes `<sha>-linux-<arch>` and the merge job assembles `<sha>` manifest.
- [ ] Push a tag at the SAME commit; confirm `docker_build` now pushes `<tag>-linux-<arch>` (not `<sha>-linux-<arch>`) and merge assembles the `<tag>` manifest — no immutable-tag error.
- [ ] Confirm explicit `imageTag` input still takes precedence (unchanged behavior).