### PR TITLE
security(BPT-005): document input trust boundary in reusable workflows

### DIFF
--- a/.github/workflows/reusable_github_release.yml
+++ b/.github/workflows/reusable_github_release.yml
@@ -1,5 +1,11 @@
 name: Reusable Release Workflow
 
+# Security (Coinspect BPT-005): caller-supplied `workflow_call` inputs are passed
+# into shell steps only via `env:` and referenced as quoted variables — never
+# interpolated directly as `${{ inputs.* }}` inside `run:`. This workflow pins
+# `runs-on: ubuntu-24.04`, so callers cannot redirect it onto a privileged
+# self-hosted / Docker-in-Docker runner. Do NOT change it to run on such a runner.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable_go_lint_test.yml
+++ b/.github/workflows/reusable_go_lint_test.yml
@@ -1,5 +1,13 @@
 name: Reusable Go Build, Lint, and Test Workflow
 
+# Security (Coinspect BPT-005): caller-supplied `workflow_call` inputs are passed
+# into shell steps only via `env:` and referenced as quoted variables — never
+# interpolated directly as `${{ inputs.* }}` inside `run:`. The `*-command`
+# inputs below are TRUSTED command inputs executed in a shell by design; only
+# grant call access to this workflow to trusted callers. This workflow pins
+# `runs-on: ubuntu-24.04`, so callers cannot redirect it onto a privileged
+# self-hosted / Docker-in-Docker runner. Do NOT change it to run on such a runner.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable_node_lint_test.yml
+++ b/.github/workflows/reusable_node_lint_test.yml
@@ -1,5 +1,13 @@
 name: Reusable Node.js Build, Lint, and Test Workflow
 
+# Security (Coinspect BPT-005): caller-supplied `workflow_call` inputs are passed
+# into shell steps only via `env:` and referenced as quoted variables — never
+# interpolated directly as `${{ inputs.* }}` inside `run:`. The `publish-command`
+# input is a TRUSTED command input executed in a shell by design; only grant call
+# access to this workflow to trusted callers. This workflow pins
+# `runs-on: ubuntu-24.04`, so callers cannot redirect it onto a privileged
+# self-hosted / Docker-in-Docker runner. Do NOT change it to run on such a runner.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable_sync_branch.yml
+++ b/.github/workflows/reusable_sync_branch.yml
@@ -1,5 +1,11 @@
 name: Sync Branch
 
+# Security (Coinspect BPT-005): caller-supplied `workflow_call` inputs are passed
+# into shell steps only via `env:` and referenced as quoted variables — never
+# interpolated directly as `${{ inputs.* }}` inside `run:`. This workflow pins
+# `runs-on: ubuntu-24.04`, so callers cannot redirect it onto a privileged
+# self-hosted / Docker-in-Docker runner. Do NOT change it to run on such a runner.
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## What

Adds an explicit security comment block to the four reusable workflows named in Coinspect finding BPT-005 (`reusable_sync_branch.yml`, `reusable_github_release.yml`, `reusable_go_lint_test.yml`, `reusable_node_lint_test.yml`), documenting the input trust boundary and warning against running them on privileged runners.

## Why

BPT-005 (Medium) flagged that these reusable workflows executed caller-controlled `workflow_call` inputs in shell contexts, creating a command-injection path that could escalate to EC2 host control if run on the self-hosted privileged Docker-in-Docker runner.

The substantive injection sinks (e.g. `base_branch=${{ inputs.base_branch }}` interpolated directly into shell) were already remediated in PR #76, which moved all shell-consumed inputs into `env:` blocks referenced as quoted variables. Additionally, all four workflows pin `runs-on: ubuntu-24.04`, so a caller cannot redirect them onto the privileged DinD runner — structurally removing the EC2-escalation vector for these files.

The only residual pattern is `eval "$CMD"` on inputs whose documented purpose is to run a caller-supplied command (`install-dependencies-command`, `integration-tests-command`, `publish-command`). These are trusted command inputs by design; removing `eval` would break callers that pass compound commands without materially reducing risk (design-reviewed with Codex).

This PR therefore completes the finding's recommendation ("do not interpolate inputs directly into shell contexts" / "remove privileges associated with DinD") on the documentation side: it records that inputs are only consumed via `env:`, marks the command-typed inputs as trusted-by-design, and warns maintainers not to move these workflows to a privileged self-hosted / DinD runner.

## Test notes

- Documentation-only change (comments); no workflow logic modified.
- All four YAML files parse cleanly (`yaml.safe_load`).
- Repo has no yamllint config and does not enforce yamllint in CI.

Refs https://github.com/babylonlabs-io/devops-backlog/issues/116

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>